### PR TITLE
DBWAL implementation

### DIFF
--- a/src/main/java/com/qubole/streamx/s3/S3SinkConnectorConfig.java
+++ b/src/main/java/com/qubole/streamx/s3/S3SinkConnectorConfig.java
@@ -13,8 +13,32 @@ public class S3SinkConnectorConfig extends HdfsSinkConnectorConfig {
     public static final String WAL_CLASS_DEFAULT = "com.qubole.streamx.s3.wal.DBWAL";
     private static final String WAL_CLASS_DISPLAY = "WAL Class";
 
+    public static final String DB_CONNECTION_URL_CONFIG = "db.connection.url";
+    private static final String DB_CONNECTION_URL_DOC =
+            "JDBC Connection URL. Required when using DBWAL (which is the default WAL implementation for S3)";
+    public static final String DB_CONNECTION_URL_DEFAULT = "";
+    private static final String DB_CONNECTION_URL_DISPLAY = "JDBC Connection URL";
+
+    public static final String DB_USER_CONFIG = "db.user";
+    private static final String DB_USER_DOC =
+            "Name of the User that has access to the database. Required when using DBWAL (which is the default WAL implementation for S3)";
+    public static final String DB_USER_DEFAULT = "";
+    private static final String DB_USER_DISPLAY = "DB User";
+
+    public static final String DB_PASSWORD_CONFIG = "db.password";
+    private static final String DB_PASSWORD_DOC =
+            "Password of the user specificed using db.user. Required when using DBWAL (which is the default WAL implementation for S3)";
+    public static final String DB_PASSWORD_DEFAULT = "";
+    private static final String DB_PASSWORD_DISPLAY = "DB Password";
+
+    public static final String WAL_GROUP = "DBWAL";
+
+
     static {
-        config.define(WAL_CLASS_CONFIG, ConfigDef.Type.STRING, WAL_CLASS_DEFAULT, ConfigDef.Importance.LOW, WAL_CLASS_DOC, INTERNAL_GROUP, 1, ConfigDef.Width.MEDIUM, WAL_CLASS_DISPLAY);
+        config.define(WAL_CLASS_CONFIG, ConfigDef.Type.STRING, WAL_CLASS_DEFAULT, ConfigDef.Importance.LOW, WAL_CLASS_DOC, WAL_GROUP, 1, ConfigDef.Width.MEDIUM, WAL_CLASS_DISPLAY);
+        config.define(DB_CONNECTION_URL_CONFIG, ConfigDef.Type.STRING, DB_CONNECTION_URL_DEFAULT, ConfigDef.Importance.LOW, DB_CONNECTION_URL_DOC, WAL_GROUP, 1, ConfigDef.Width.MEDIUM, DB_CONNECTION_URL_DISPLAY);
+        config.define(DB_USER_CONFIG, ConfigDef.Type.STRING, DB_USER_DEFAULT, ConfigDef.Importance.LOW, DB_USER_DOC, WAL_GROUP, 1, ConfigDef.Width.MEDIUM, DB_USER_DISPLAY);
+        config.define(DB_PASSWORD_CONFIG, ConfigDef.Type.STRING, DB_PASSWORD_DEFAULT, ConfigDef.Importance.LOW, DB_PASSWORD_DOC, WAL_GROUP, 1, ConfigDef.Width.MEDIUM, DB_PASSWORD_DISPLAY);
     }
 
 

--- a/src/main/java/com/qubole/streamx/s3/S3SinkConnectorConfig.java
+++ b/src/main/java/com/qubole/streamx/s3/S3SinkConnectorConfig.java
@@ -1,0 +1,25 @@
+package com.qubole.streamx.s3;
+
+import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+import java.util.Map;
+
+public class S3SinkConnectorConfig extends HdfsSinkConnectorConfig {
+
+    public static final String WAL_CLASS_CONFIG = "wal.class";
+    private static final String WAL_CLASS_DOC =
+            "WAL implementation to use. Use RDSWAL if you need exactly once guarantee (applies for s3)";
+    public static final String WAL_CLASS_DEFAULT = "com.qubole.streamx.s3.wal.DBWAL";
+    private static final String WAL_CLASS_DISPLAY = "WAL Class";
+
+    static {
+        config.define(WAL_CLASS_CONFIG, ConfigDef.Type.STRING, WAL_CLASS_DEFAULT, ConfigDef.Importance.LOW, WAL_CLASS_DOC, INTERNAL_GROUP, 1, ConfigDef.Width.MEDIUM, WAL_CLASS_DISPLAY);
+    }
+
+
+    public S3SinkConnectorConfig(Map<String, String> props) {
+        super(props);
+    }
+
+}

--- a/src/main/java/com/qubole/streamx/s3/S3SinkConnectorConfig.java
+++ b/src/main/java/com/qubole/streamx/s3/S3SinkConnectorConfig.java
@@ -33,12 +33,19 @@ public class S3SinkConnectorConfig extends HdfsSinkConnectorConfig {
 
     public static final String WAL_GROUP = "DBWAL";
 
+    public static final String NAME_CONFIG = "name";
+    private static final String NAME_DOC =
+            "Name of the connector";
+    public static final String NAME_DEFAULT = "";
+    private static final String NAME_DISPLAY = "Connector Name";
+
 
     static {
         config.define(WAL_CLASS_CONFIG, ConfigDef.Type.STRING, WAL_CLASS_DEFAULT, ConfigDef.Importance.LOW, WAL_CLASS_DOC, WAL_GROUP, 1, ConfigDef.Width.MEDIUM, WAL_CLASS_DISPLAY);
         config.define(DB_CONNECTION_URL_CONFIG, ConfigDef.Type.STRING, DB_CONNECTION_URL_DEFAULT, ConfigDef.Importance.LOW, DB_CONNECTION_URL_DOC, WAL_GROUP, 1, ConfigDef.Width.MEDIUM, DB_CONNECTION_URL_DISPLAY);
         config.define(DB_USER_CONFIG, ConfigDef.Type.STRING, DB_USER_DEFAULT, ConfigDef.Importance.LOW, DB_USER_DOC, WAL_GROUP, 1, ConfigDef.Width.MEDIUM, DB_USER_DISPLAY);
         config.define(DB_PASSWORD_CONFIG, ConfigDef.Type.STRING, DB_PASSWORD_DEFAULT, ConfigDef.Importance.LOW, DB_PASSWORD_DOC, WAL_GROUP, 1, ConfigDef.Width.MEDIUM, DB_PASSWORD_DISPLAY);
+        config.define(NAME_CONFIG, ConfigDef.Type.STRING, NAME_DEFAULT, ConfigDef.Importance.HIGH, NAME_DOC, CONNECTOR_GROUP,1, ConfigDef.Width.MEDIUM, NAME_DISPLAY);
     }
 
 

--- a/src/main/java/com/qubole/streamx/s3/S3Storage.java
+++ b/src/main/java/com/qubole/streamx/s3/S3Storage.java
@@ -9,6 +9,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.kafka.common.TopicPartition;
+import java.io.*;
 
 import java.io.IOException;
 import java.net.URI;
@@ -47,7 +48,12 @@ public class S3Storage implements Storage {
 
     @Override
     public boolean exists(String filename) throws IOException {
-        return fs.exists(new Path(filename));
+        try {
+            BufferedReader br = new BufferedReader(new InputStreamReader(fs.open(new Path(filename))));
+        } catch(IOException e){
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/com/qubole/streamx/s3/S3Storage.java
+++ b/src/main/java/com/qubole/streamx/s3/S3Storage.java
@@ -115,10 +115,12 @@ public class S3Storage implements Storage {
         final Path srcPath = new Path(sourcePath);
         final Path dstPath = new Path(targetPath);
         FileSystem localFs = FileSystem.get(srcPath.toUri(),hadoopConf);
-
+        fs.rename(srcPath, dstPath);
+        /*
         if (localFs.exists(srcPath)) {
             fs.copyFromLocalFile(false, srcPath, dstPath);
             //fs.rename(srcPath, dstPath);
-        }
+        }*/
+
     }
 }

--- a/src/main/java/com/qubole/streamx/s3/wal/DBWAL.java
+++ b/src/main/java/com/qubole/streamx/s3/wal/DBWAL.java
@@ -264,7 +264,11 @@ public class DBWAL implements  WAL {
 
     @Override
     public void close() throws ConnectException {
-
+        try {
+            connection.close();
+        } catch (SQLException e) {
+            throw new ConnectException("Unable to close connection",e);
+        }
     }
 
     @Override

--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -14,6 +14,8 @@
 
 package io.confluent.connect.hdfs;
 
+import com.qubole.streamx.s3.S3SinkConnectorConfig;
+import io.confluent.connect.hdfs.wal.WAL;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -165,7 +167,9 @@ public class DataWriter {
 
       Class<? extends Storage> storageClass = (Class<? extends Storage>) Class
               .forName(connectorConfig.getString(HdfsSinkConnectorConfig.STORAGE_CLASS_CONFIG));
-      storage = StorageFactory.createStorage(storageClass, conf, url);
+      Class<? extends WAL> walClass = (Class<? extends WAL>) Class
+              .forName(connectorConfig.getString(S3SinkConnectorConfig.WAL_CLASS_CONFIG));
+      storage = StorageFactory.createStorage(storageClass, walClass, conf, url);
 
       createDir(topicsDir);
       createDir(topicsDir + HdfsSinkConnecorConstants.TEMPFILE_DIRECTORY);

--- a/src/main/java/io/confluent/connect/hdfs/DataWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/DataWriter.java
@@ -167,9 +167,8 @@ public class DataWriter {
 
       Class<? extends Storage> storageClass = (Class<? extends Storage>) Class
               .forName(connectorConfig.getString(HdfsSinkConnectorConfig.STORAGE_CLASS_CONFIG));
-      Class<? extends WAL> walClass = (Class<? extends WAL>) Class
-              .forName(connectorConfig.getString(S3SinkConnectorConfig.WAL_CLASS_CONFIG));
-      storage = StorageFactory.createStorage(storageClass, walClass, conf, url);
+
+      storage = StorageFactory.createStorage(storageClass, connectorConfig, conf, url);
 
       createDir(topicsDir);
       createDir(topicsDir + HdfsSinkConnecorConstants.TEMPFILE_DIRECTORY);

--- a/src/main/java/io/confluent/connect/hdfs/FileUtils.java
+++ b/src/main/java/io/confluent/connect/hdfs/FileUtils.java
@@ -73,7 +73,8 @@ public class FileUtils {
                                     String extension) {
     UUID id = UUID.randomUUID();
     String name = id.toString() + "_" + "tmp" + extension;
-    return localFileName(url, topicsDir, directory, name);
+    //return localFileName(url, topicsDir, directory, name);
+    return fileName(url, topicsDir, directory, name);
   }
 
   public static String committedFileName(String url, String topicsDir, String directory,

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnector.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnector.java
@@ -15,6 +15,7 @@
 package io.confluent.connect.hdfs;
 
 
+import com.qubole.streamx.s3.S3SinkConnectorConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.connector.Connector;
@@ -46,7 +47,7 @@ public class HdfsSinkConnector extends Connector {
   public void start(Map<String, String> props) throws ConnectException {
     try {
       configProperties = props;
-      config = new HdfsSinkConnectorConfig(props);
+      config = new S3SinkConnectorConfig(props);
     } catch (ConfigException e) {
       throw new ConnectException("Couldn't start HdfsSinkConnector due to configuration error", e);
     }

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -253,7 +253,7 @@ public class HdfsSinkConnectorConfig extends AbstractConfig {
   private static final ConfigDef.Recommender partitionerClassDependentsRecommender = new PartitionerClassDependentsRecommender();
   private static final ConfigDef.Recommender schemaCompatibilityRecommender = new SchemaCompatibilityRecommender();
 
-  private static ConfigDef config = new ConfigDef();
+  protected static ConfigDef config = new ConfigDef();
 
   static {
 

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -15,7 +15,8 @@
 package io.confluent.connect.hdfs;
 
 import com.qubole.streamx.s3.S3SinkConnectorConstants;
-import com.qubole.streamx.s3.wal.RDSWal;
+import com.qubole.streamx.s3.wal.DBWAL;
+import com.qubole.streamx.s3.wal.DBWAL;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -459,7 +460,7 @@ public class TopicPartitionWriter {
 
   private void resetOffsets() throws ConnectException {
     if (!recovered) {
-      if(wal instanceof RDSWal)
+      if(wal instanceof DBWAL)
         readOffsetFromWAL();
       else
         readOffset();

--- a/src/main/java/io/confluent/connect/hdfs/storage/StorageFactory.java
+++ b/src/main/java/io/confluent/connect/hdfs/storage/StorageFactory.java
@@ -15,6 +15,7 @@
 package io.confluent.connect.hdfs.storage;
 
 import com.qubole.streamx.s3.S3Storage;
+import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
 import io.confluent.connect.hdfs.wal.WAL;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -24,12 +25,12 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
 public class StorageFactory {
-  public static Storage createStorage(Class<? extends Storage> storageClass, Class<? extends WAL> walClass, Configuration conf, String url) {
+  public static Storage createStorage(Class<? extends Storage> storageClass, HdfsSinkConnectorConfig config, Configuration conf, String url) {
     try {
       Constructor<? extends Storage> ctor = null;
       if(storageClass == S3Storage.class) {
-        ctor = storageClass.getConstructor(Configuration.class, Class.class, String.class);
-        return ctor.newInstance(conf, walClass, url);
+        ctor = storageClass.getConstructor(Configuration.class, HdfsSinkConnectorConfig.class, String.class);
+        return ctor.newInstance(conf, config, url);
       }
       else {
         ctor = storageClass.getConstructor(Configuration.class, String.class);

--- a/src/main/java/io/confluent/connect/hdfs/storage/StorageFactory.java
+++ b/src/main/java/io/confluent/connect/hdfs/storage/StorageFactory.java
@@ -14,6 +14,8 @@
 
 package io.confluent.connect.hdfs.storage;
 
+import com.qubole.streamx.s3.S3Storage;
+import io.confluent.connect.hdfs.wal.WAL;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.velocity.exception.MethodInvocationException;
@@ -22,11 +24,17 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
 public class StorageFactory {
-  public static Storage createStorage(Class<? extends Storage> storageClass, Configuration conf, String url) {
+  public static Storage createStorage(Class<? extends Storage> storageClass, Class<? extends WAL> walClass, Configuration conf, String url) {
     try {
-      Constructor<? extends Storage> ctor =
-          storageClass.getConstructor(Configuration.class, String.class);
-      return ctor.newInstance(conf, url);
+      Constructor<? extends Storage> ctor = null;
+      if(storageClass == S3Storage.class) {
+        ctor = storageClass.getConstructor(Configuration.class, Class.class, String.class);
+        return ctor.newInstance(conf, walClass, url);
+      }
+      else {
+        ctor = storageClass.getConstructor(Configuration.class, String.class);
+        return ctor.newInstance(conf, url);
+      }
     } catch (NoSuchMethodException | InvocationTargetException | MethodInvocationException | InstantiationException | IllegalAccessException e) {
       throw new ConnectException(e);
     }

--- a/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
@@ -161,4 +161,9 @@ public class FSWAL implements WAL {
   public String getLogFile() {
     return logFile;
   }
+
+  @Override
+  public long readOffsetFromWAL() {
+    throw new ConnectException("Reading offset from WAL is not supported in MemoryWAL");
+  }
 }

--- a/src/main/java/io/confluent/connect/hdfs/wal/WAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/WAL.java
@@ -27,4 +27,5 @@ public interface WAL {
   void truncate() throws ConnectException;
   void close() throws ConnectException;
   String getLogFile();
+  long readOffsetFromWAL();
 }

--- a/src/test/java/io/confluent/connect/hdfs/utils/MemoryWAL.java
+++ b/src/test/java/io/confluent/connect/hdfs/utils/MemoryWAL.java
@@ -95,6 +95,11 @@ public class MemoryWAL implements WAL {
     return logFile;
   }
 
+  @Override
+  public long readOffsetFromWAL() {
+    throw new ConnectException("Reading offset from WAL is not supported in MemoryWAL");
+  }
+
   private static class LogEntry {
     private String key;
     private String value;


### PR DESCRIPTION
In HDFS, WAL is stored in HDFS. This cant be done in s3 as s3 doesnt support append and is also eventually consistent. This PR introduces DBWAL to store WAL file in DB. 

wal.class = com.qubole.streamx.s3.wal.DBWAL by default. So it requires user to configure the following.

> db.connection.url
> db.user
> db.password

Here is an example configuration :

```
{"name":"twitter connector",
"config":{
"name":"twitter connector",
"connector.class":"io.confluent.connect.hdfs.HdfsSinkConnector",
"tasks.max":"1",
"flush.size":"1000",
"hdfs.url":"<s3 location>",
  "wal.class":"com.qubole.streamx.s3.wal.DBWAL",
  "db.connection.url":"jdbc:mysql://localhost:3306/kafka",
  "db.user":"root",
  "db.password":"sss",
"hadoop.conf.dir":"/usr/lib/hadoop2/etc/hadoop/",
"topics":"election"}}
```

Note : If you dont need exactly-once-guarantee, just use MemoryWAL for wal.class instead.
