### PR TITLE
Dockerize StreamX

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+src
+target/*
+!target/streamx-0.1.0-SNAPSHOT-development

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,15 @@ MAINTAINER pseluka@qubole.com
 RUN apt-get update && apt-get install -y vim
 
 ENV STREAMX_DIR /usr/local/streamx
-ADD ["target/streamx-0.1.0-SNAPSHOT-development/share/java/streamx","/usr/local/streamx"]
-ADD ["config","/usr/local/streamx/config"]
-ENV CLASSPATH=$CLASSPATH:/usr/local/streamx/*
 
-VOLUME ["/var/lib/streamx/log"]
-
-ADD ["docker/entry", "/usr/local/streamx/entry"]
-ADD ["docker/utils.py", "/usr/local/streamx/utils.py"]
-RUN chmod 777 /usr/local/streamx/entry
+ADD target/streamx-0.1.0-SNAPSHOT-development/share/java/streamx /usr/local/streamx
+ADD config /usr/local/streamx/config
+ADD docker/entry /usr/local/streamx/entry
+ADD docker/utils.py /usr/local/streamx/utils.py
 
 EXPOSE 8083
+
+ENV CLASSPATH=$CLASSPATH:/usr/local/streamx/*
+
+RUN chmod 777 /usr/local/streamx/entry
 CMD ["bash","/usr/local/streamx/entry"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM confluentinc/cp-kafka:3.0.0
+
+MAINTAINER pseluka@qubole.com
+
+RUN apt-get update && apt-get install -y vim
+
+ENV STREAMX_DIR /usr/local/streamx
+ADD ["target/streamx-0.1.0-SNAPSHOT-development/share/java/streamx","/usr/local/streamx"]
+ADD ["config","/usr/local/streamx/config"]
+ENV CLASSPATH=$CLASSPATH:/usr/local/streamx/*
+
+VOLUME ["/var/lib/streamx/log"]
+
+ADD ["docker/entry", "/usr/local/streamx/entry"]
+ADD ["docker/utils.py", "/usr/local/streamx/utils.py"]
+RUN chmod 777 /usr/local/streamx/entry
+
+EXPOSE 8083
+CMD ["bash","/usr/local/streamx/entry"]

--- a/config/connect-distributed.properties
+++ b/config/connect-distributed.properties
@@ -1,0 +1,54 @@
+##
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+
+# These are defaults. This file just demonstrates how to override some settings.
+bootstrap.servers=localhost:9092
+
+# unique name for the cluster, used in forming the Connect cluster group. Note that this must not conflict with consumer group IDs
+group.id=connect-cluster
+rest.port=8083
+
+# The converters specify the format of data in Kafka and how to translate it into Connect data. Every Connect user will
+# need to configure these based on the format they want their data in when loaded from or stored into Kafka
+
+key.converter=com.qubole.streamx.ByteArrayConverter
+value.converter=com.qubole.streamx.ByteArrayConverter
+
+# Converter-specific settings can be passed in by prefixing the Converter's setting with the converter we want to apply
+# it to
+#key.converter.schemas.enable=false
+#value.converter.schemas.enable=false
+
+# The internal converter used for offsets and config data is configurable and must be specified, but most users will
+# always want to use the built-in default. Offset and config data is never visible outside of Kafka Connect in this format.
+internal.key.converter=org.apache.kafka.connect.json.JsonConverter
+internal.value.converter=org.apache.kafka.connect.json.JsonConverter
+internal.key.converter.schemas.enable=false
+internal.value.converter.schemas.enable=false
+
+# Topic to use for storing offsets. This topic should have many partitions and be replicated.
+offset.storage.topic=connect-offsets
+
+# Topic to use for storing connector and task configurations; note that this should be a single partition, highly replicated topic.
+# You may need to manually create the topic to ensure single partition for the config topic as auto created topics may have multiple partitions.
+config.storage.topic=connect-configs
+
+# Topic to use for storing statuses. This topic can have multiple partitions and should be replicated.
+status.storage.topic=connect-status
+
+# Flush much faster than normal, which is useful for testing/debugging
+offset.flush.interval.ms=10000

--- a/docker/entry
+++ b/docker/entry
@@ -1,0 +1,16 @@
+env_vars=`env | grep CONNECT`
+
+# Override connect-distributed.properties with env_vars
+python /usr/local/streamx/utils.py $env_vars
+if [ $? -eq 1 ]; then
+ echo "Exiting : Streamx startup script utils.py exited with non-zero exit code"
+ exit
+fi
+
+CONNECT_CONF=/usr/local/streamx/config/connect-distributed-override.properties
+
+cat $CONNECT_CONF
+
+# Launch StreamX
+export CLASSPATH=/usr/local/streamx/*
+/usr/bin/connect-distributed $CONNECT_CONF

--- a/docker/entry
+++ b/docker/entry
@@ -2,7 +2,7 @@ env_vars=`env | grep CONNECT`
 
 # Override connect-distributed.properties with env_vars
 python /usr/local/streamx/utils.py $env_vars
-if [ $? -eq 1 ]; then
+if [ $? -ne 0 ]; then
  echo "Exiting : Streamx startup script utils.py exited with non-zero exit code"
  exit
 fi

--- a/docker/utils.py
+++ b/docker/utils.py
@@ -1,0 +1,72 @@
+import sys
+
+def print_help():
+  print """ The following properties must be configured using env variables
+  CONNECT_BOOTSTRAP_SERVERS
+  CONNECT_AWS_ACCESS_KEY
+  CONNECT_AWS_SECRET_KEY
+  Cmd : docker run -d --env CONNECT_BOOTSTRAP_SERVERS=public_dns:9092 --env CONNECT_AWS_ACCESS_KEY=xxxxx --env CONNECT_AWS_SECRET_KEY=yyyy qubole/streamx"""
+
+def check_for_required_configs(confs):
+  if len(confs) == 0:
+    print_help()
+    sys.exit(1)
+
+  required_configs = {"CONNECT_BOOTSTRAP_SERVERS": False, "CONNECT_AWS_ACCESS_KEY": False, "CONNECT_AWS_SECRET_KEY": False}
+  for x in required_configs.keys():
+    if x in confs:
+       required_configs[x] = True
+
+  for x in required_configs.keys():
+    if required_configs[x] == False:
+      print x +" is required"
+      sys.exit(1)
+
+def override_connect_configs(confs):
+  connect_file = "/usr/local/streamx/config/connect-distributed.properties"
+  connect_override_file = "/usr/local/streamx/config/connect-distributed-override.properties"
+  with open(connect_file) as f:
+    connect_conf = f.read().splitlines()
+
+  # env_vars will be of format CONNECT_BOOTSTRAP_SERVERS corresponding to bootstrap.servers. 
+  # This code converts the env_vars into later format
+  for k,v in confs.items():
+    #remove CONNECT_ prefix
+    k = k[8:]
+    key = k.lower().replace("_",".")
+      
+    # override connect_conf with env_vars
+    for i in range(0, len(connect_conf)):
+      if connect_conf[i].startswith(key):
+        connect_conf[i] = key + "=" + v
+
+  with open(connect_override_file,'w') as f:
+    for line in connect_conf:
+      f.write(line+"\n")
+
+def override_hadoop_configs(confs):
+  hadoop_conf_file = "/usr/local/streamx/config/hadoop-conf/hdfs-site.xml"
+  access_key = confs["CONNECT_AWS_ACCESS_KEY"] 
+  secret_key = confs["CONNECT_AWS_SECRET_KEY"]
+  import subprocess
+  cmd1='sed -i "s:SECRET_KEY_HERE:' + secret_key + ':g" /usr/local/streamx/config/hadoop-conf/hdfs-site.xml'
+  cmd2='sed -i "s:ACCESS_KEY_HERE:' + access_key + ':g" /usr/local/streamx/config/hadoop-conf/hdfs-site.xml'
+  subprocess.Popen(cmd1, shell=True).wait()
+  subprocess.Popen(cmd2, shell=True).wait()
+
+def main():
+  confs = {}
+  for x in range(1,len(sys.argv)):
+    if sys.argv[x].startswith("CONNECT"):
+      (k, v) = sys.argv[x].split("=", 1)
+      confs[k] = v
+    else:
+      print "Ignoring " + x + " as it does not start with CONNECT_"
+
+  check_for_required_configs(confs)
+  override_connect_configs(confs)
+  override_hadoop_configs(confs)
+
+if __name__ == "__main__":
+  main()
+


### PR DESCRIPTION
Dockerfile to build StreamX docker image. Contains entry and utils.py which are helper functions to launch StreamX. Utils.py takes the env variables passed to docker and uses that to override configuration

`docker run -d --net=host --env CONNECT_BOOTSTRAP_SERVERS=localhost:29092 --env CONNECT_AWS_SECRET_KEY=yyy--env CONNECT_AWS_ACCESS_KEY=xxx  --env CONNECT_REST_PORT=8085 streamx`